### PR TITLE
Seed users and enhance login

### DIFF
--- a/Personal+/Login.Designer.cs
+++ b/Personal+/Login.Designer.cs
@@ -32,6 +32,7 @@
             this.checkBox1 = new System.Windows.Forms.CheckBox();
             this.Text_Login = new System.Windows.Forms.TextBox();
             this.Text_Pass = new System.Windows.Forms.TextBox();
+            this.btnShowPass = new System.Windows.Forms.Button();
             this.label2 = new System.Windows.Forms.Label();
             this.Pass = new System.Windows.Forms.Label();
             this.SuspendLayout();
@@ -69,6 +70,17 @@
             this.Text_Pass.Name = "Text_Pass";
             this.Text_Pass.Size = new System.Drawing.Size(229, 26);
             this.Text_Pass.TabIndex = 4;
+            this.Text_Pass.UseSystemPasswordChar = true;
+            //
+            // btnShowPass
+            //
+            this.btnShowPass.Location = new System.Drawing.Point(399, 189);
+            this.btnShowPass.Name = "btnShowPass";
+            this.btnShowPass.Size = new System.Drawing.Size(122, 26);
+            this.btnShowPass.TabIndex = 7;
+            this.btnShowPass.Text = "Показати";
+            this.btnShowPass.UseVisualStyleBackColor = true;
+            this.btnShowPass.Click += new System.EventHandler(this.btnShowPass_Click);
             // 
             // label2
             // 
@@ -95,6 +107,7 @@
             this.ClientSize = new System.Drawing.Size(556, 364);
             this.Controls.Add(this.Pass);
             this.Controls.Add(this.label2);
+            this.Controls.Add(this.btnShowPass);
             this.Controls.Add(this.Text_Pass);
             this.Controls.Add(this.Text_Login);
             this.Controls.Add(this.checkBox1);
@@ -112,6 +125,7 @@
         private System.Windows.Forms.CheckBox checkBox1;
         private System.Windows.Forms.TextBox Text_Login;
         private System.Windows.Forms.TextBox Text_Pass;
+        private System.Windows.Forms.Button btnShowPass;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Label Pass;
     }

--- a/Personal+/Login.cs
+++ b/Personal+/Login.cs
@@ -18,6 +18,15 @@ namespace Personal_
             InitializeComponent();
             this.AcceptButton = btnLogin;
             btnLogin.Click += Login_Click;
+            btnShowPass.Click += btnShowPass_Click;
+            Text_Pass.UseSystemPasswordChar = true;
+
+            if (Properties.Settings.Default.RememberMe)
+            {
+                Text_Login.Text = Properties.Settings.Default.Login;
+                Text_Pass.Text = Properties.Settings.Default.Password;
+                checkBox1.Checked = true;
+            }
         }
 
         private async void Login_Click(object sender, EventArgs e)
@@ -37,11 +46,28 @@ namespace Personal_
                 MessageBox.Show("Невірний логін або пароль.", "Помилка", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
+
+            if (checkBox1.Checked)
+            {
+                Properties.Settings.Default.Login = login;
+                Properties.Settings.Default.Password = pass;
+                Properties.Settings.Default.RememberMe = true;
+            }
+            else
+            {
+                Properties.Settings.Default.Login = string.Empty;
+                Properties.Settings.Default.Password = string.Empty;
+                Properties.Settings.Default.RememberMe = false;
+            }
+            Properties.Settings.Default.Save();
+
             Session.CurrentUserLogin = login;
             this.Hide();
-             using var mainForm = new Form1();
-            mainForm.FormClosed += (s, args) => this.Close();
-            mainForm.ShowDialog();
+            using (var mainForm = new Form1())
+            {
+                mainForm.FormClosed += (s, args) => this.Close();
+                mainForm.ShowDialog();
+            }
         }
 
         private void MainForm_FormClosed(object sender, FormClosedEventArgs e)
@@ -51,13 +77,19 @@ namespace Personal_
 
         private async Task<bool> AuthenticateAsync(string login, string pass)
         {
-            using var db = new AppDbContext();
+            using (var db = new AppDbContext())
+            {
+                // Retrieve the user by login and validate the hashed password
+                var user = await db.Users.FirstOrDefaultAsync(u => u.Login == login);
+                if (user == null) return false;
 
-            // Retrieve the user by login and validate the hashed password
-            var user = await db.Users.FirstOrDefaultAsync(u => u.Login == login);
-            if (user == null) return false;
-
-            return BCrypt.Net.BCrypt.Verify(pass, user.Password);
+                return BCrypt.Net.BCrypt.Verify(pass, user.Password);
+            }
+        }
+        private void btnShowPass_Click(object sender, EventArgs e)
+        {
+            Text_Pass.UseSystemPasswordChar = !Text_Pass.UseSystemPasswordChar;
+            btnShowPass.Text = Text_Pass.UseSystemPasswordChar ? "Показати" : "Сховати";
         }
         private void RememberMe_CheckedChanged(object sender, EventArgs e)
         {

--- a/Personal+/Program.cs
+++ b/Personal+/Program.cs
@@ -17,7 +17,7 @@ namespace Personal_
         {
             try
             {
-                SeedData.EnsureAdminExists();
+                SeedData.SeedUsers();
             }
             catch (Exception ex)
             {

--- a/Personal+/Properties/Settings.Designer.cs
+++ b/Personal+/Properties/Settings.Designer.cs
@@ -26,5 +26,50 @@ namespace Personal_.Properties
                 return defaultInstance;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string Login
+        {
+            get
+            {
+                return ((string)(this["Login"]));
+            }
+            set
+            {
+                this["Login"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string Password
+        {
+            get
+            {
+                return ((string)(this["Password"]));
+            }
+            set
+            {
+                this["Password"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool RememberMe
+        {
+            get
+            {
+                return ((bool)(this["RememberMe"]));
+            }
+            set
+            {
+                this["RememberMe"] = value;
+            }
+        }
     }
 }

--- a/Personal+/Properties/Settings.settings
+++ b/Personal+/Properties/Settings.settings
@@ -3,5 +3,15 @@
   <Profiles>
     <Profile Name="(Default)" />
   </Profiles>
-  <Settings />
+  <Settings>
+    <Setting Name="Login" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="Password" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="RememberMe" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+  </Settings>
 </SettingsFile>

--- a/Personal+/SeedData.cs
+++ b/Personal+/SeedData.cs
@@ -8,34 +8,33 @@ namespace Personal_
 {
     public class SeedData
     {
-        public static void EnsureAdminExists()
+        public static void SeedUsers()
         {
-            using var db = new AppDbContext();
-            if (!db.Users.Any(u => u.Login == "admin"))
-            {
-                var hash = BCrypt.Net.BCrypt.HashPassword("Assasin123");
-                db.Users.Add(new User
-                {
-                    Login = "admin",
-                    Password = hash,
-                    IsActive = true,
-                });
-                db.SaveChanges();
-            }
+            CreateUser("dina", "dina123");
+            CreateUser("oksana", "oksana123");
+            CreateUser("sasha", "sasha123");
+            CreateUser("zhenya", "zhenya123");
+            CreateUser("vitalik", "vitalik123");
+            CreateUser("stas", "stas123");
+            CreateUser("yura", "admin123", true);
         }
 
-        public static void CreateUsar(string login, string plainPassword) {
-            using var db = new AppDbContext();
-            if (!db.Users.Any(u => u.Login == login))
+        private static void CreateUser(string login, string plainPassword, bool isAdmin = false)
+        {
+            using (var db = new AppDbContext())
             {
-                var hash = BCrypt.Net.BCrypt.HashPassword(plainPassword);
-                db.Users.Add(new User
+                if (!db.Users.Any(u => u.Login == login))
                 {
-                    Login = login,
-                    Password = hash,
-                    IsActive = true,
-                });
-                db.SaveChanges();
+                    var hash = BCrypt.Net.BCrypt.HashPassword(plainPassword);
+                    db.Users.Add(new User
+                    {
+                        Login = login,
+                        Password = hash,
+                        IsActive = true,
+                        IsAdmin = isAdmin,
+                    });
+                    db.SaveChanges();
+                }
             }
         }
     }

--- a/Personal+/User.cs
+++ b/Personal+/User.cs
@@ -12,5 +12,6 @@ namespace Personal_
         public string Login { get; set; }
         public string Password { get; set; }
         public bool IsActive { get; set; }
+        public bool IsAdmin { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- Seed database with predefined users including admin
- Hide password entry by default and allow toggling visibility
- Remember login and password when requested

## Testing
- `xbuild ../Personal+.sln | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6890ccad6a50832ba5a50ab3b5a35c63