### PR TITLE
Make forms static with larger fixed window sizes

### DIFF
--- a/Personal+/ChatForm.Designer.cs
+++ b/Personal+/ChatForm.Designer.cs
@@ -125,12 +125,14 @@ namespace Personal_
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
-            this.ClientSize = new System.Drawing.Size(584, 361);
+            this.ClientSize = new System.Drawing.Size(800, 600);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Controls.Add(this.listViewMessages);
             this.Controls.Add(this.panelInput);
             this.Font = new System.Drawing.Font("Segoe UI", 10F);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Sizable;
-            this.MaximizeBox = true;
             this.Name = "ChatForm";
             this.Text = "Чат";
             this.Load += new System.EventHandler(this.ChatForm_Load);

--- a/Personal+/Form1.Designer.cs
+++ b/Personal+/Form1.Designer.cs
@@ -471,6 +471,9 @@
             this.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.BackColor = System.Drawing.Color.LightSteelBlue;
             this.ClientSize = new System.Drawing.Size(800, 600);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Controls.Add(this.btnChat);
             this.Controls.Add(this.btnForward);

--- a/Personal+/Login.Designer.cs
+++ b/Personal+/Login.Designer.cs
@@ -104,7 +104,11 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(556, 364);
+            this.ClientSize = new System.Drawing.Size(800, 600);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Controls.Add(this.Pass);
             this.Controls.Add(this.label2);
             this.Controls.Add(this.btnShowPass);

--- a/Personal+/NotificationForm.cs
+++ b/Personal+/NotificationForm.cs
@@ -11,8 +11,9 @@ namespace Personal_
             Text = $"Повідомлення від {sender}";
             FormBorderStyle = FormBorderStyle.FixedDialog;
             StartPosition = FormStartPosition.CenterParent;
-            AutoSize = true;
-            AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            ClientSize = new Size(800, 600);
+            MaximizeBox = false;
+            MinimizeBox = false;
 
             var pic = new PictureBox
             {

--- a/Personal+/PersonnelForm.cs
+++ b/Personal+/PersonnelForm.cs
@@ -61,6 +61,10 @@ namespace Personal_
             this.Text = "Персонал";
             this.Width = 1200;
             this.Height = 700;
+            this.FormBorderStyle = FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.StartPosition = FormStartPosition.CenterScreen;
 
             txtSearch.SetBounds(10, 10, 200, 25);
             btnSearch.Text = "Пошук";


### PR DESCRIPTION
## Summary
- fix Form1 to use a fixed dialog border, disable maximize/minimize, and keep an 800×600 client area
- enlarge Login window and make all forms unresizable with fixed borders
- apply the same static 800×600 sizing to Chat and notification dialogs and Personnel form

## Testing
- `dotnet build` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*