### PR TITLE
Add chat and notification buttons

### DIFF
--- a/Personal+/Form1.Designer.cs
+++ b/Personal+/Form1.Designer.cs
@@ -73,6 +73,8 @@
             this.listView1 = new System.Windows.Forms.ListView();
             this.btnBack = new System.Windows.Forms.Button();
             this.btnForward = new System.Windows.Forms.Button();
+            this.btnChat = new System.Windows.Forms.Button();
+            this.btnNotify = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
             this.SuspendLayout();
             // 
@@ -455,6 +457,28 @@
             this.btnForward.UseVisualStyleBackColor = true;
             this.btnForward.Click += new System.EventHandler(this.btnForward_Click);
             //
+            // btnChat
+            //
+            this.btnChat.Location = new System.Drawing.Point(10, 520);
+            this.btnChat.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.btnChat.Name = "btnChat";
+            this.btnChat.Size = new System.Drawing.Size(80, 35);
+            this.btnChat.TabIndex = 39;
+            this.btnChat.Text = "Чат";
+            this.btnChat.UseVisualStyleBackColor = true;
+            this.btnChat.Click += new System.EventHandler(this.btnChat_Click);
+            //
+            // btnNotify
+            //
+            this.btnNotify.Location = new System.Drawing.Point(100, 520);
+            this.btnNotify.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.btnNotify.Name = "btnNotify";
+            this.btnNotify.Size = new System.Drawing.Size(120, 35);
+            this.btnNotify.TabIndex = 40;
+            this.btnNotify.Text = "Сповіщення";
+            this.btnNotify.UseVisualStyleBackColor = true;
+            this.btnNotify.Click += new System.EventHandler(this.btnNotify_Click);
+            //
             // Form1
             //
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
@@ -500,6 +524,8 @@
             this.Controls.Add(this.label2);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.pictureBox1);
+            this.Controls.Add(this.btnNotify);
+            this.Controls.Add(this.btnChat);
             this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.Name = "Form1";
             this.RightToLeftLayout = true;
@@ -554,6 +580,8 @@
         private System.Windows.Forms.ListView listView1;
         private System.Windows.Forms.Button btnBack;
         private System.Windows.Forms.Button btnForward;
+        private System.Windows.Forms.Button btnChat;
+        private System.Windows.Forms.Button btnNotify;
     }
 }
 

--- a/Personal+/Form1.cs
+++ b/Personal+/Form1.cs
@@ -71,29 +71,6 @@ namespace Personal_
             imageList.ImageSize = new Size(32, 32);
             listView1.LargeImageList = imageList;
             listView1.TileSize = new Size(150, 36);
-
-            var chatBtn = new Button { Text = "Чат", Left = 10, Top = 520, Width = 80 };
-            chatBtn.Click += (s, e) =>
-            {
-                using (var f = new ChatForm(Login.Session.CurrentUser))
-                {
-                    f.ShowDialog();
-                }
-            };
-            Controls.Add(chatBtn);
-
-            var notifyBtn = new Button { Text = "Сповіщення", Left = 100, Top = 520, Width = 120 };
-            notifyBtn.Click += (s, e) =>
-            {
-                var user = Login.Session.CurrentUser;
-                if (user != null && user.IsAdmin)
-                {
-                    var text = Prompt("Текст сповіщення:");
-                    if (!string.IsNullOrWhiteSpace(text))
-                        NotificationService.CreateNotification(text, user.Id);
-                }
-            };
-            Controls.Add(notifyBtn);
         }
 
         private void Form1_Load(object sender, EventArgs e)
@@ -115,6 +92,25 @@ namespace Personal_
                 form.Controls.AddRange(new Control[] { label, box, buttonOk });
                 form.AcceptButton = buttonOk;
                 return form.ShowDialog() == DialogResult.OK ? box.Text : null;
+            }
+        }
+
+        private void btnChat_Click(object sender, EventArgs e)
+        {
+            using (var f = new ChatForm(Login.Session.CurrentUser))
+            {
+                f.ShowDialog();
+            }
+        }
+
+        private void btnNotify_Click(object sender, EventArgs e)
+        {
+            var user = Login.Session.CurrentUser;
+            if (user != null && user.IsAdmin)
+            {
+                var text = Prompt("Текст сповіщення:");
+                if (!string.IsNullOrWhiteSpace(text))
+                    NotificationService.CreateNotification(text, user.Id);
             }
         }
 


### PR DESCRIPTION
## Summary
- Add chat and notification buttons to Form1 and wire up their click handlers
- Remove runtime button creation and integrate buttons into designer layout

## Testing
- `apt-get update`
- `apt-get install -y mono-devel`
- `xbuild Personal+.sln` *(fails: missing EntityFramework package)*