### PR TITLE
Maximize KTVP and Personnel windows

### DIFF
--- a/Personal+/KTVPForm.cs
+++ b/Personal+/KTVPForm.cs
@@ -95,8 +95,9 @@ namespace Personal_
         private void InitializeComponent()
         {
             Text = "КТВП";
-            Width = 900;
-            Height = 1000;
+            WindowState = FormWindowState.Maximized;
+            FormBorderStyle = FormBorderStyle.FixedSingle;
+            MaximizeBox = false;
 
             panel.Dock = DockStyle.Fill;
             panel.AutoScroll = true;
@@ -295,8 +296,20 @@ namespace Personal_
                 lstBottom
             });
 
+            foreach (Control ctrl in panel.Controls)
+            {
+                if (ctrl is Button)
+                    ctrl.Anchor = AnchorStyles.Top | AnchorStyles.Left;
+            }
+
+            lstBottom.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right | AnchorStyles.Bottom;
+
             Controls.Add(panel);
-            Resize += (s, e) => lstBottom.Width = panel.ClientSize.Width - 20;
+            Resize += (s, e) =>
+            {
+                lstBottom.Width = panel.ClientSize.Width - 20;
+                lstBottom.Height = panel.ClientSize.Height - lstBottom.Top - 10;
+            };
         }
 
         private void BtnIdSearch_Click(object sender, EventArgs e)

--- a/Personal+/PersonnelForm.cs
+++ b/Personal+/PersonnelForm.cs
@@ -59,8 +59,9 @@ namespace Personal_
         private void InitializeComponent()
         {
             this.Text = "Персонал";
-            this.Width = 1200;
-            this.Height = 700;
+            this.WindowState = FormWindowState.Maximized;
+            this.FormBorderStyle = FormBorderStyle.FixedSingle;
+            this.MaximizeBox = false;
 
             txtSearch.SetBounds(10, 10, 200, 25);
             btnSearch.Text = "Пошук";
@@ -131,6 +132,14 @@ namespace Personal_
                 txtSearch, btnSearch, cmbDepartments, btnClear, btnGroupSearch,
                 chkAll, chkOfficers, chkSergeants, chkSoldiers, btnExport, grid
             });
+
+            foreach (Control ctrl in this.Controls)
+            {
+                if (ctrl is Button)
+                    ctrl.Anchor = AnchorStyles.Top | AnchorStyles.Left;
+            }
+
+            grid.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right | AnchorStyles.Bottom;
         }
 
         private void RankChanged(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- Open КТВП and Штат forms maximized with a fixed border to prevent resizing.
- Anchor buttons and stretch KТВП list box to fill the remaining vertical space.